### PR TITLE
Sub-module compatibility fix for Node.js versions >= 0.11.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "url": "https://github.com/JakubOnderka/api-blueprint-validator.git"
   },
   "engines": {
-    "node": ">=0.8.15"
+    "node": ">=0.11.x"
   },
   "dependencies": {
-    "protagonist": "0.11.0",
+    "protagonist": ">=0.19.3",
     "yargs": "1.2.1",
     "jsonlint": "1.6.0"
   },


### PR DESCRIPTION
Instead of shrinkwrapping things, I figured I'd just submit a PR.
