### PR TITLE
lock protagonist to 0.19.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=0.11.x"
   },
   "dependencies": {
-    "protagonist": ">=0.19.3",
+    "protagonist": "^0.19.3",
     "yargs": "1.2.1",
     "jsonlint": "1.6.0"
   },


### PR DESCRIPTION
Installing api-blueprint-validator fresh right now causes the installation of protagonist 1.0.0. This version appears to require changes to api-blueprint-validator:

``` bash
Warning: Command failed: /bin/sh -c node ./node_modules/.bin/api-blueprint-validator ./services/introduction.md
.../node_modules/api-blueprint-validator/src/validator.js:74
      result.warnings.forEach(function (warning) {
                     ^
TypeError: Cannot read property 'forEach' of undefined
    at .../node_modules/api-blueprint-validator/src/validator.js:74:22

Aborted due to warnings.
```

This change locks the version down to 0.19.x, which is a temporary fix until the library can be updated to accommodate any changes made in protagonist.
