### PR TITLE
+  protagonist@1.0.0 (by markatom) + option fail-on-wornings (by markatom) +  option requireBlueprintName (by dougbeasley) + fix isJsonContentType() (by cherehapa)+ check schemas & their definitions (by cherehapa)

### DIFF
--- a/bin/api-blueprint-validator
+++ b/bin/api-blueprint-validator
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 var yargs = require('yargs')
     .usage('Usage: $0 apiary.apib ')
-    .boolean(['validate-requests', 'validate-responses'])
+    .boolean(['validate-requests', 'validate-responses', 'fail-on-warnings'])
     .default('validate-requests', true)
-    .default('validate-responses', true),
+    .default('validate-responses', true)
+    .default('fail-on-warnings', false),
   argv = yargs.argv;
 
 if (argv.help) {
@@ -18,4 +19,4 @@ if (argv._[0] === undefined) {
 }
 
 var validator = require('../src/validator');
-validator(argv._[0], argv.validateRequests, argv.validateResponses);
+validator(argv._[0], argv.validateRequests, argv.validateResponses, argv.failOnWarnings);

--- a/bin/api-blueprint-validator
+++ b/bin/api-blueprint-validator
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 var yargs = require('yargs')
     .usage('Usage: $0 apiary.apib ')
-    .boolean(['validate-requests', 'validate-responses', 'fail-on-warnings'])
+    .boolean(['validate-requests', 'validate-responses', 'fail-on-warnings', 'require-name'])
     .default('validate-requests', true)
     .default('validate-responses', true)
-    .default('fail-on-warnings', false),
+    .default('fail-on-warnings', false)
+    .default('require-name', false),
   argv = yargs.argv;
 
 if (argv.help) {
@@ -19,4 +20,4 @@ if (argv._[0] === undefined) {
 }
 
 var validator = require('../src/validator');
-validator(argv._[0], argv.validateRequests, argv.validateResponses, argv.failOnWarnings);
+validator(argv._[0], argv.validateRequests, argv.validateResponses, argv.failOnWarnings, argv.requireName);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=0.11.x"
   },
   "dependencies": {
-    "protagonist": ">=0.19.3",
+    "protagonist": ">=1.0.0",
     "yargs": "1.2.1",
     "jsonlint": "1.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "is-glob": "^2.0.1",
     "jsonlint": "1.6.0",
     "yargs": "1.2.1",
+    "ajv":"^4.9.0",
     "protagonist": ">=1.0.0"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "node": ">=0.11.x"
   },
   "dependencies": {
-    "protagonist": ">=1.0.0",
+    "glob-fs": "^0.1.6",
+    "is-glob": "^2.0.1",
+    "jsonlint": "1.6.0",
     "yargs": "1.2.1",
-    "jsonlint": "1.6.0"
+    "protagonist": ">=1.0.0"
   },
   "license": "MIT"
 }

--- a/src/validator.js
+++ b/src/validator.js
@@ -64,7 +64,7 @@ module.exports = function (fileName, validateRequests, validateResponses) {
       return;
     }
 
-    protagonist.parse(data, function (error, result) {
+    protagonist.parse(data, {type: 'ast'}, function (error, result) {
       if (error) {
         var lineNumber = lineNumberFromCharacterIndex(data, error.location[0].index);
         console.error('Error: ' + error.message + ' on line ' + lineNumber);

--- a/src/validator.js
+++ b/src/validator.js
@@ -1,9 +1,114 @@
 var fs = require('fs'),
+  glob = require('glob-fs')({ gitignore: true }),
+  isGlob = require('is-glob'),
   protagonist = require('protagonist'),
   jsonParser = require('jsonlint').parser;
 
 function lineNumberFromCharacterIndex(string, index) {
   return string.substring(0, index).split("\n").length;
+}
+
+function hasImportantWarning(result,parserOptions) {
+  has_important_warnings = False;
+  result.warnings.forEach(function(warning) {
+    if ((warning.indexOf('expected API name') !== -1) && ! parserOptions.requireBlueprintName) return;
+    has_important_warnings = True;
+  });
+  return has_important_warnings;
+}
+
+function lint(file, data, options) {
+
+  function shouldSkip(event) {
+    return (!options.requireBlueprintName && event.message.indexOf('expected API name') !== -1 );
+  }
+
+  var parserOptions = {
+    requireBlueprintName: options.requireBlueprintName,
+    type: 'ast'
+  };
+  
+  protagonist.parse(data, parserOptions, function (error, result) {
+
+      if (error) {
+        var lineNumber = lineNumberFromCharacterIndex(data, error.location[0].index);
+        console.error('(' + file + ')' + ' ' + 'Error: ' + error.message + ' on line ' + lineNumber);
+        process.exit(1);
+      }
+
+      if(result.wanrings) {
+        result.warnings.forEach(function (warning) {
+          if (!shouldSkip(warning)) {
+            var lineNumber = lineNumberFromCharacterIndex(data, warning.location[0].index);
+            console.error('(' + file + ')' + ' ' + 'Warning: ' + warning.message + ' on line ' + lineNumber);
+          }
+        });
+      }
+
+      var errors = [];
+
+      if(result.ast) {
+        examples(result.ast, function (example, action, resource, resourceGroup) {
+          if (options.validateRequests) {
+            example.requests.forEach(function (request) {
+              var valid = isValidRequestOrResponse(request);
+              if (valid !== true) {
+                var message = '    ' + valid.message.replace(/\n/g, '\n    ');
+                var position = errorPosition(example, action, resource, resourceGroup);
+                errors.push('(' + file + ')' + ' ' + 'Error in JSON request ' + position + '\n' + message);
+              }
+            });
+          }
+
+          if (options.validateResponses) {
+            example.responses.forEach(function (response) {
+              var valid = isValidRequestOrResponse(response);
+              if (valid !== true) {
+                var message = '    ' + valid.message.replace(/\n/g, '\n    ');
+                var position = errorPosition(example, action, resource, resourceGroup);
+                errors.push('(' + file + ')' + ' ' + 'Error in JSON response ' + position + '\n' + message);
+              }
+            });
+          }
+        });
+      }
+
+      if (errors.length > 0) {
+        console.error(errors.join('\n\n'));
+      }
+
+      if (errors.length > 0 ||
+            ( options.failOnWarnings &&
+              ( result.warnings.length > 0 && hasImportantWarning(result.warnings,parserOptions) )
+            )
+         ) {
+        process.exit(1);
+      }
+    });
+}
+
+function processFile(path, options) {
+  fs.readFile(path, 'utf8', function (error, data) {
+    if (error) {
+      console.error('Could not open ' + path);
+      process.exit(1); 
+    }
+    else {
+      lint(path, data, options);
+    }
+  });
+}
+
+function processGlob(path, options) {
+    glob.readdir(path, function (error, files) {
+      if (error) {
+        console.error('Unable to read files ' + path);
+        process.exit(1); 
+      }
+      files.forEach(function (path) {
+        processFile(path, options);
+      });
+     });
 }
 
 function examples(ast, callback) {
@@ -57,62 +162,22 @@ function errorPosition(example, action, resource, resourceGroup) {
   return 'in ' + output.join(', ');
 }
 
-module.exports = function (fileName, validateRequests, validateResponses, failOnWarnings) {
-  fs.readFile(fileName, 'utf8', function (error, data) {
-    if (error) {
-      console.error('Could not open ' + fileName);
-      return;
-    }
+module.exports = function (fileName, validateRequests, validateResponses, failOnWarnings, requireBlueprintName ) {
+  
+   var options = {
+     validateRequests: validateRequests,
+     validateResponses: validateResponses,
+     failOnWarnings: failOnWarnings,
+     requireBlueprintName: requireBlueprintName
+   };
 
-    protagonist.parse(data, {type: 'ast'}, function (error, result) {
-      if (error) {
-        var lineNumber = lineNumberFromCharacterIndex(data, error.location[0].index);
-        console.error('Error: ' + error.message + ' on line ' + lineNumber);
-        process.exit(1);
-      }
+  if (isGlob(fileName)) {
+    // never require the blueprint name for multiple files
+    options.requireBlueprintName = false;
+    processGlob(fileName, options);
+  }
+  else {
+    processFile(fileName, options);
+  }
 
-      if(result.wanrings) {
-        result.warnings.forEach(function (warning) {
-          var lineNumber = lineNumberFromCharacterIndex(data, warning.location[0].index);
-          console.error('Warning: ' + warning.message + ' on line ' + lineNumber);
-        });
-      }
-
-      var errors = [];
-
-      if(result.ast) {
-        examples(result.ast, function (example, action, resource, resourceGroup) {
-          if (validateRequests) {
-            example.requests.forEach(function (request) {
-              var valid = isValidRequestOrResponse(request);
-              if (valid !== true) {
-                var message = '    ' + valid.message.replace(/\n/g, '\n    ');
-                var position = errorPosition(example, action, resource, resourceGroup);
-                errors.push('Error in JSON request ' + position + '\n' + message);
-              }
-            });
-          }
-
-          if (validateResponses) {
-            example.responses.forEach(function (response) {
-              var valid = isValidRequestOrResponse(response);
-              if (valid !== true) {
-                var message = '    ' + valid.message.replace(/\n/g, '\n    ');
-                var position = errorPosition(example, action, resource, resourceGroup);
-                errors.push('Error in JSON response ' + position + '\n' + message);
-              }
-            });
-          }
-        });
-      }
-
-      if (errors.length > 0) {
-        console.error(errors.join('\n\n'));
-      }
-
-      if (errors.length > 0 || failOnWarnings && result.warnings.length > 0) {
-        process.exit(1);
-      }
-    });
-  });
 };

--- a/src/validator.js
+++ b/src/validator.js
@@ -71,36 +71,40 @@ module.exports = function (fileName, validateRequests, validateResponses, failOn
         process.exit(1);
       }
 
-      result.warnings.forEach(function (warning) {
-        var lineNumber = lineNumberFromCharacterIndex(data, warning.location[0].index);
-        console.error('Warning: ' + warning.message + ' on line ' + lineNumber);
-      });
+      if(result.wanrings) {
+        result.warnings.forEach(function (warning) {
+          var lineNumber = lineNumberFromCharacterIndex(data, warning.location[0].index);
+          console.error('Warning: ' + warning.message + ' on line ' + lineNumber);
+        });
+      }
 
       var errors = [];
 
-      examples(result.ast, function (example, action, resource, resourceGroup) {
-        if (validateRequests) {
-          example.requests.forEach(function (request) {
-            var valid = isValidRequestOrResponse(request);
-            if (valid !== true) {
-              var message = '    ' + valid.message.replace(/\n/g, '\n    ');
-              var position = errorPosition(example, action, resource, resourceGroup);
-              errors.push('Error in JSON request ' + position + '\n' + message);
-            }
-          });
-        }
+      if(result.ast) {
+        examples(result.ast, function (example, action, resource, resourceGroup) {
+          if (validateRequests) {
+            example.requests.forEach(function (request) {
+              var valid = isValidRequestOrResponse(request);
+              if (valid !== true) {
+                var message = '    ' + valid.message.replace(/\n/g, '\n    ');
+                var position = errorPosition(example, action, resource, resourceGroup);
+                errors.push('Error in JSON request ' + position + '\n' + message);
+              }
+            });
+          }
 
-        if (validateResponses) {
-          example.responses.forEach(function (response) {
-            var valid = isValidRequestOrResponse(response);
-            if (valid !== true) {
-              var message = '    ' + valid.message.replace(/\n/g, '\n    ');
-              var position = errorPosition(example, action, resource, resourceGroup);
-              errors.push('Error in JSON response ' + position + '\n' + message);
-            }
-          });
-        }
-      });
+          if (validateResponses) {
+            example.responses.forEach(function (response) {
+              var valid = isValidRequestOrResponse(response);
+              if (valid !== true) {
+                var message = '    ' + valid.message.replace(/\n/g, '\n    ');
+                var position = errorPosition(example, action, resource, resourceGroup);
+                errors.push('Error in JSON response ' + position + '\n' + message);
+              }
+            });
+          }
+        });
+      }
 
       if (errors.length > 0) {
         console.error(errors.join('\n\n'));

--- a/src/validator.js
+++ b/src/validator.js
@@ -10,10 +10,10 @@ function lineNumberFromCharacterIndex(string, index) {
 }
 
 function hasImportantWarning(result,parserOptions) {
-  has_important_warnings = False;
+  has_important_warnings = false;
   result.warnings.forEach(function(warning) {
     if ((warning.indexOf('expected API name') !== -1) && ! parserOptions.requireBlueprintName) return;
-    has_important_warnings = True;
+    has_important_warnings = true;
   });
   return has_important_warnings;
 }

--- a/src/validator.js
+++ b/src/validator.js
@@ -125,8 +125,8 @@ function examples(ast, callback) {
 
 function isJsonContentType(headers) {
   return headers.some(function (header) {
-    return header.name === 'Content-Type' && header.value === 'application/json';
-  });
+    return header.name === 'Content-Type' && /application\/json/.test(header.value); // header may also contain other info, i.e. encoding:
+  });                                                                                 //"application/json; charset=utf-8", so use regexp here.
 }
 
 function isValidRequestOrResponse(requestOrResponse) {

--- a/src/validator.js
+++ b/src/validator.js
@@ -57,7 +57,7 @@ function errorPosition(example, action, resource, resourceGroup) {
   return 'in ' + output.join(', ');
 }
 
-module.exports = function (fileName, validateRequests, validateResponses) {
+module.exports = function (fileName, validateRequests, validateResponses, failOnWarnings) {
   fs.readFile(fileName, 'utf8', function (error, data) {
     if (error) {
       console.error('Could not open ' + fileName);
@@ -104,6 +104,9 @@ module.exports = function (fileName, validateRequests, validateResponses) {
 
       if (errors.length > 0) {
         console.error(errors.join('\n\n'));
+      }
+
+      if (errors.length > 0 || failOnWarnings && result.warnings.length > 0) {
         process.exit(1);
       }
     });

--- a/src/validator.js
+++ b/src/validator.js
@@ -11,10 +11,12 @@ function lineNumberFromCharacterIndex(string, index) {
 
 function hasImportantWarning(result,parserOptions) {
   has_important_warnings = false;
+  if(result.wanrings) {
   result.warnings.forEach(function(warning) {
     if ((warning.indexOf('expected API name') !== -1) && ! parserOptions.requireBlueprintName) return;
     has_important_warnings = true;
   });
+  }
   return has_important_warnings;
 }
 


### PR DESCRIPTION
+  protagonist@1.0.0 (by markatom) + option fail-on-wornings (by markatom):  just a merge of changes requested by markatom in pull requests #10 & #11

 +  option requireBlueprintName (by dougbeasley):  similar to changes requested by dougbeasley in pull request #14 

+ fix isJsonContentType() (by cherehapa):  determine json by regexp: Content-type may contain also encoding, i.e. allow headers like:
 Content-Type: application/json; charset=utf-8
(no pull requests yet w/ similar functionality (up to 2016Dec9)).

+ check schemas & their definitions (by cherehapa):  if blueprint defines "+Schema", then it should appear in .schema after protagonist.parse. We add check of it to be a correct json (whish is similar to  #15 (except logging improvement, which is not needed in our case))  + add check of it for json schema rules via ajv schema validator module (no pull requests yet w/ similar functionality(up to 2016Dec9)).
